### PR TITLE
Unpin version of Meshes.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,3 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
 MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
-
-[compat]
-Meshes = "< 0.35"


### PR DESCRIPTION
Meshes.jl has changed its API: https://github.com/JuliaGeometry/Meshes.jl/pull/574
and as such `MeshData` is not available anymore.

See error at: https://github.com/ProjectTorreyPines/FUSE.jl/actions/runs/6080388435/job/16494282468

@lstagner please update https://github.com/ProjectTorreyPines/MeshTools.jl/blob/10b9057b5a14457bf2eea3ac33fde0280c397fe5/src/interpolation.jl#L46 to work with the latest versions of Meshes.jl

Thanks!!